### PR TITLE
Fix broken links to docs in API plugin repo

### DIFF
--- a/guides/extending.md
+++ b/guides/extending.md
@@ -16,9 +16,8 @@ want to work with custom post types, also read the [Working With Posts][] guide.
 You should also have a pretty good knowledge of working with actions and filters
 in WordPress, as well as how plugins work in general.
 
-[Getting Started]: getting-started.md
-[Working with Posts]: working-with-posts.md
-
+[Getting Started]: http://wp-api.org/guides.html#getting-started
+[Working with Posts]: http://wp-api.org/guides.html#working-with-posts
 
 A Philosophy Lesson
 -------------------
@@ -350,6 +349,6 @@ improving the built-in APIs.
   own entity design.
 * [Internal Implementation][]: Learn about how the REST server works internally.
 
-[API Philosophy]: ../internals/philosophy.md
-[Schema]: ../schema.md
-[Internal Implementation]: ../internals/implementation.md
+[API Philosophy]: https://github.com/WP-API/WP-API/blob/master/docs/internals/philosophy.md
+[Schema]: https://github.com/WP-API/WP-API/blob/master/docs/schema.md
+[Internal Implementation]: https://github.com/WP-API/WP-API/blob/master/docs/internals/implementation.md

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -468,7 +468,7 @@ get exploring!
 * [Schema][schema]: View technical information on all the available data
 * [Authentication][auth]: Explore authentication options
 
-[Working with Posts]: working-with-posts.md
-[schema]: ../schema.md
-[auth]: ../authentication.md
+[Working with Posts]: http://wp-api.org/guides.html#working-with-posts
+[schema]: https://github.com/WP-API/WP-API/blob/master/docs/schema.md
+[auth]: https://github.com/WP-API/WP-API/blob/master/docs/authentication.md
 [basic-auth-plugin]: https://github.com/WP-API/Basic-Auth

--- a/guides/working-with-posts.md
+++ b/guides/working-with-posts.md
@@ -280,8 +280,8 @@ take a look at the other APIs, or look at documentation on the specifics.
 * [Schema][schema]: Full documentation of every parameter for the APIs.
 * [Extending the API][]: Create your own API endpoints.
 
-[Getting Started]: getting-started.md
-[Extending the API]: extending.md
-[schema]: ../schema.md
+[Getting Started]: http://wp-api.org/guides.html#getting-started
+[Extending the API]: http://wp-api.org/guides.html#extending-the-api
+[schema]: https://github.com/WP-API/WP-API/blob/master/docs/schema.md
 [WP_Query]: http://codex.wordpress.org/Class_Reference/WP_Query
-[array-style URL formatting]: ../compatibility.md#inputting-data-as-an-array
+[array-style URL formatting]: https://github.com/WP-API/WP-API/blob/master/docs/compatibility.md#inputting-data-as-an-array


### PR DESCRIPTION
Fixes #11.

This fix links to docs in their current locations. I don't know whether the plan is to ultimately migrate all docs from the plugin repo into this docs repo, but figure this makes sense in the short term, either way. 

Sideenote: I noticed that the Github Pages live site at wp-api.org is behind source, in that some live links are broken that are already fixed in this repo. I'm curious what is the process for re-generating the live site, and how often that happens. Can it be automated to recompile when `master` is updated here?
