### PR TITLE
Wrong variable name

### DIFF
--- a/guides/extending.md
+++ b/guides/extending.md
@@ -274,7 +274,7 @@ hooking and more for you:
 
 		require_once dirname( __FILE__ ) . '/class-myplugin-api-mytype.php';
 		$myplugin_api_mytype = new MyPlugin_API_MyType( $server );
-		$myplugin->register_filters();
+		$myplugin_api_mytype->register_filters();
 	}
 	add_action( 'wp_json_server_before_serve', 'myplugin_api_init' );
 


### PR DESCRIPTION
There was a wrong variable name in the exemple of adding endpoint extending WP_JSON_CustomPostType
