### PR TITLE
Update pygments configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 baseurl: /
-pygments: true
+highlighter: pygments
 markdown: kramdown
 kramdown:
     input: GFM


### PR DESCRIPTION
Resolve the following deprecation warning: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.