### PR TITLE
Switch to the rawgithub CDN for hotlinking the Flatdoc JS files.

### DIFF
--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -16,7 +16,7 @@ title: WP REST API Documentation
 	<link rel="stylesheet" href="{{ site.baseurl }}stylesheets/styles.css">
 	<link rel="stylesheet" href="{{ site.baseurl }}stylesheets/pygment_trac.css">
 
-	<script src="http://rstacruz.github.io/flatdoc/v/0.8.0/theme-white/script.js"></script>
+	<script src="https://cdn.rawgit.com/rstacruz/flatdoc/gh-pages/theme-white/script.js"></script>
 	<script src="{{ site.baseurl }}js/sidebar.js"></script>
 
 	<!-- Meta -->

--- a/_layouts/internals.html
+++ b/_layouts/internals.html
@@ -16,7 +16,7 @@ title: WP REST API Documentation
   <link rel="stylesheet" href="{{ site.baseurl }}stylesheets/styles.css">
   <link rel="stylesheet" href="{{ site.baseurl }}stylesheets/pygment_trac.css">
 
-  <script src="http://rstacruz.github.io/flatdoc/v/0.8.0/theme-white/script.js"></script>
+  <script src="https://cdn.rawgit.com/rstacruz/flatdoc/gh-pages/theme-white/script.js"></script>
   <script src="{{ site.baseurl }}js/sidebar.js"></script>
 
   <!-- Meta -->

--- a/index.html
+++ b/index.html
@@ -12,13 +12,13 @@ title: WP API Documentation
 
 	<!-- Flatdoc -->
 	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-	<script src="http://rstacruz.github.io/flatdoc/v/0.8.0/legacy.js"></script>
-	<script src="http://rstacruz.github.io/flatdoc/v/0.8.0/flatdoc.js"></script>
+	<script src="https://cdn.rawgit.com/rstacruz/flatdoc/gh-pages/legacy.js"></script>
+	<script src="https://cdn.rawgit.com/rstacruz/flatdoc/gh-pages/flatdoc.js"></script>
 
 	<link rel="stylesheet" href="{{ site.baseurl }}stylesheets/styles.css">
 	<link rel="stylesheet" href="{{ site.baseurl }}stylesheets/pygment_trac.css">
 
-	<script src="http://rstacruz.github.io/flatdoc/v/0.8.0/theme-white/script.js"></script>
+	<script src="https://cdn.rawgit.com/rstacruz/flatdoc/gh-pages/theme-white/script.js"></script>
 
 	<!-- Meta -->
 	<meta content="WP API" property="og:title">


### PR DESCRIPTION
Resolves urgent issue of site appearing blank.  See https://github.com/WP-API/WP-API/issues/584
