### PR TITLE
Fixed some broken links within the guides/ section

### DIFF
--- a/guides/extending.md
+++ b/guides/extending.md
@@ -355,5 +355,5 @@ improving the built-in APIs.
 * [Internal Implementation][]: Learn about how the REST server works internally.
 
 [API Philosophy]: ../internals/philosophy.html
-[Schema]: ../schema.html
+[Schema]: ../../
 [Internal Implementation]: ../internals/implementation.html

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -473,6 +473,6 @@ get exploring!
 * [Authentication][auth]: Explore authentication options
 
 [Working with Posts]: working-with-posts.html
-[schema]: ../schema.html
-[auth]: ../authentication.html
+[schema]: ../../
+[auth]: authentication.html
 [basic-auth-plugin]: https://github.com/WP-API/Basic-Auth

--- a/guides/working-with-posts.md
+++ b/guides/working-with-posts.md
@@ -286,6 +286,6 @@ take a look at the other APIs, or look at documentation on the specifics.
 
 [Getting Started]: getting-started.html
 [Extending the API]: extending.html
-[schema]: ../schema.html
+[schema]: ../../
 [WP_Query]: http://codex.wordpress.org/Class_Reference/WP_Query
 [array-style URL formatting]: ../compatibility.html#inputting-data-as-an-array


### PR DESCRIPTION
Some of the "Next Steps" links at the bottom of the guide pages were pointing to nonexistent pages. References to schema.html have also been updated to point to the docs homepage.