### PR TITLE
Fix incorrectly rendered bash code block

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -72,6 +72,7 @@ you'll need to create a "consumer". This is an identifier for the application,
 and includes a "key" and "secret", both needed to link to your site.
 
 To create the consumer, run the following on your server:
+
 ```bash
 $ wp oauth1 add
 


### PR DESCRIPTION
According to [Carwin's Markdown Style Guidelines](https://github.com/carwin/markdown-styleguide):
> Fenced code blocks must be preceded and followed by a newline.

This change adds a newline so that Jekyll will render the code block correctly.